### PR TITLE
Add debug level configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,7 +926,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "panw-api-ollama"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panw-api-ollama"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/config.yaml.exemple
+++ b/config.yaml.exemple
@@ -2,6 +2,7 @@
 server:
   host: "0.0.0.0"
   port: 11435  # Same port as Ollama uses by default
+  debug_level: "ERROR"
 
 ollama:
   base_url: "http://localhost:11434"  # Actual Ollama instance on different port

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,7 @@ pub struct Config {
 pub struct ServerConfig {
     pub host: String,
     pub port: u16,
+    pub debug_level: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
Introduce a debug level setting in the configuration file, allowing dynamic adjustment of logging verbosity for the server.