### PR TITLE
Replace 500 errors with formatted block messages for security violations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,12 +299,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -312,6 +328,17 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -348,6 +375,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -932,6 +960,7 @@ dependencies = [
  "axum",
  "bytes",
  "chrono",
+ "futures",
  "futures-util",
  "http-body-util",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ bytes = "1.5.0"
 async-stream = "0.3.5"
 http-body-util = "0.1.0"
 chrono = { version = "0.4", features = ["serde"] }
+futures = "0.3"

--- a/src/handlers/chat.rs
+++ b/src/handlers/chat.rs
@@ -4,7 +4,7 @@ use tracing::{debug, error, info};
 use crate::handlers::utils::{build_json_response, handle_streaming_request};
 use crate::handlers::ApiError;
 use crate::stream::SecurityAssessable;
-use crate::types::ChatRequest;
+use crate::types::{ChatRequest, ChatResponse, Message};
 use crate::AppState;
 
 impl SecurityAssessable for crate::types::ChatResponse {
@@ -33,10 +33,32 @@ pub async fn handle_chat(
                 "Security issue detected in chat message: category={}, action={}",
                 assessment.category, assessment.action
             );
-            return Err(ApiError::SecurityIssue(format!(
-                "Message content violates security policy. Category: {}, Action: {}",
+
+            // Instead of returning an error, create a response with explanation
+            let blocked_message = format!(
+                "⚠️ This response was blocked due to security policy violations:\n\n\
+                • Category: {}\n\
+                • Action: {}\n\n\
+                Please reformulate your request to comply with security policies.",
                 assessment.category, assessment.action
-            )));
+            );
+
+            let response = ChatResponse {
+                model: request.model.clone(),
+                created_at: chrono::Utc::now().to_rfc3339(),
+                message: Message {
+                    role: "assistant".to_string(),
+                    content: blocked_message,
+                },
+                done: true,
+            };
+
+            let json_bytes = serde_json::to_vec(&response).map_err(|e| {
+                error!("Failed to serialize response: {}", e);
+                ApiError::InternalError("Failed to serialize response".to_string())
+            })?;
+
+            return Ok(build_json_response(bytes::Bytes::from(json_bytes))?);
         }
     }
 
@@ -54,8 +76,8 @@ pub async fn handle_chat(
         ApiError::InternalError("Failed to read response body".to_string())
     })?;
 
-    let response_body: crate::types::ChatResponse =
-        serde_json::from_slice(&body_bytes).map_err(|e| {
+    let mut response_body: crate::types::ChatResponse = serde_json::from_slice(&body_bytes)
+        .map_err(|e| {
             error!("Failed to parse response: {}", e);
             ApiError::InternalError("Failed to parse response".to_string())
         })?;
@@ -70,10 +92,24 @@ pub async fn handle_chat(
             "Security issue detected in chat response: category={}, action={}",
             assessment.category, assessment.action
         );
-        return Err(ApiError::SecurityIssue(format!(
-            "Response content violates security policy. Category: {}, Action: {}",
+
+        // Replace the content with security message instead of returning error
+        let blocked_message = format!(
+            "⚠️ This response was blocked due to security policy violations:\n\n\
+            • Category: {}\n\
+            • Action: {}\n\n\
+            Please reformulate your request to comply with security policies.",
             assessment.category, assessment.action
-        )));
+        );
+
+        response_body.message.content = blocked_message;
+
+        let json_bytes = serde_json::to_vec(&response_body).map_err(|e| {
+            error!("Failed to serialize response: {}", e);
+            ApiError::InternalError("Failed to serialize response".to_string())
+        })?;
+
+        return Ok(build_json_response(bytes::Bytes::from(json_bytes))?);
     }
 
     Ok(build_json_response(body_bytes)?)
@@ -86,11 +122,6 @@ async fn handle_streaming_chat(
     debug!("Handling streaming chat request");
 
     let model = request.model.clone();
-    handle_streaming_request::<ChatRequest, crate::types::ChatResponse>(
-        &state,
-        request,
-        "/api/chat",
-        &model,
-    )
-    .await
+    handle_streaming_request::<ChatRequest, ChatResponse>(&state, request, "/api/chat", &model)
+        .await
 }

--- a/src/handlers/generate.rs
+++ b/src/handlers/generate.rs
@@ -4,7 +4,7 @@ use tracing::{debug, error, info};
 use crate::handlers::utils::{build_json_response, handle_streaming_request};
 use crate::handlers::ApiError;
 use crate::stream::SecurityAssessable;
-use crate::types::GenerateRequest;
+use crate::types::{GenerateRequest, GenerateResponse};
 use crate::AppState;
 
 impl SecurityAssessable for crate::types::GenerateResponse {
@@ -32,10 +32,30 @@ pub async fn handle_generate(
             "Security issue detected in prompt: category={}, action={}",
             assessment.category, assessment.action
         );
-        return Err(ApiError::SecurityIssue(format!(
-            "Content violates security policy. Category: {}, Action: {}",
+
+        // Instead of returning an error, create a response with explanation
+        let blocked_message = format!(
+            "⚠️ This response was blocked due to security policy violations:\n\n\
+            • Category: {}\n\
+            • Action: {}\n\n\
+            Please reformulate your request to comply with security policies.",
             assessment.category, assessment.action
-        )));
+        );
+
+        let response = crate::types::GenerateResponse {
+            model: request.model.clone(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+            response: blocked_message,
+            context: None,
+            done: true,
+        };
+
+        let json_bytes = serde_json::to_vec(&response).map_err(|e| {
+            error!("Failed to serialize response: {}", e);
+            ApiError::InternalError("Failed to serialize response".to_string())
+        })?;
+
+        return Ok(build_json_response(bytes::Bytes::from(json_bytes))?);
     }
 
     // Handle streaming requests
@@ -56,7 +76,7 @@ pub async fn handle_generate(
         ApiError::InternalError("Failed to read response body".to_string())
     })?;
 
-    let response_body: crate::types::GenerateResponse = serde_json::from_slice(&body_bytes)
+    let mut response_body: crate::types::GenerateResponse = serde_json::from_slice(&body_bytes)
         .map_err(|e| {
             error!("Failed to parse response: {}", e);
             ApiError::InternalError("Failed to parse response".to_string())
@@ -72,10 +92,24 @@ pub async fn handle_generate(
             "Security issue detected in response: category={}, action={}",
             assessment.category, assessment.action
         );
-        return Err(ApiError::SecurityIssue(format!(
-            "Response content violates security policy. Category: {}, Action: {}",
+
+        // Replace the content with security message instead of returning error
+        let blocked_message = format!(
+            "⚠️ This response was blocked due to security policy violations:\n\n\
+            • Category: {}\n\
+            • Action: {}\n\n\
+            Please reformulate your request to comply with security policies.",
             assessment.category, assessment.action
-        )));
+        );
+
+        response_body.response = blocked_message;
+
+        let json_bytes = serde_json::to_vec(&response_body).map_err(|e| {
+            error!("Failed to serialize response: {}", e);
+            ApiError::InternalError("Failed to serialize response".to_string())
+        })?;
+
+        return Ok(build_json_response(bytes::Bytes::from(json_bytes))?);
     }
 
     Ok(build_json_response(body_bytes)?)
@@ -88,7 +122,7 @@ async fn handle_streaming_generate(
     debug!("Handling streaming generate request");
 
     let model = request.model.clone();
-    handle_streaming_request::<GenerateRequest, crate::types::GenerateResponse>(
+    handle_streaming_request::<GenerateRequest, GenerateResponse>(
         &state,
         request,
         "/api/generate",

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -11,12 +11,11 @@ use axum::{
     Json,
 };
 use serde_json::json;
-use tracing::{error, info};
+use tracing::error;
 
 pub enum ApiError {
     OllamaError(crate::ollama::OllamaError),
     SecurityError(crate::security::SecurityError),
-    SecurityIssue(String),
     InternalError(String),
 }
 
@@ -33,10 +32,6 @@ impl IntoResponse for ApiError {
                     StatusCode::INTERNAL_SERVER_ERROR,
                     format!("Security error: {}", err),
                 )
-            }
-            ApiError::SecurityIssue(msg) => {
-                info!("Security issue detected: {}", msg);
-                (StatusCode::FORBIDDEN, format!("Security issue: {}", msg))
             }
             ApiError::InternalError(msg) => {
                 error!("Internal error: {}", msg);

--- a/src/handlers/models.rs
+++ b/src/handlers/models.rs
@@ -17,7 +17,7 @@ pub struct ModelRequest {
     pub stream: Option<bool>,
 }
 
-/// Represents the available Ollama API endpoints.
+// Represents the available Ollama API endpoints.
 pub enum OllamaEndpoint {
     Tags,
     Show,
@@ -29,7 +29,7 @@ pub enum OllamaEndpoint {
 }
 
 impl OllamaEndpoint {
-    /// Returns the API path for the endpoint.
+    // Returns the API path for the endpoint.
     fn path(&self) -> &'static str {
         match self {
             Self::Tags => "/api/tags",
@@ -42,7 +42,7 @@ impl OllamaEndpoint {
         }
     }
 
-    /// Returns the HTTP method for the endpoint.
+    // Returns the HTTP method for the endpoint.
     fn method(&self) -> Method {
         match self {
             Self::Tags => Method::GET,
@@ -50,7 +50,7 @@ impl OllamaEndpoint {
         }
     }
 
-    /// Returns the appropriate log message prefix for the endpoint.
+    // Returns the appropriate log message prefix for the endpoint.
     fn log_prefix(&self) -> &'static str {
         match self {
             Self::Tags => "Forwarding list models request",
@@ -63,13 +63,13 @@ impl OllamaEndpoint {
         }
     }
 
-    /// Determines if this endpoint should include model name in logs.
+    // Determines if this endpoint should include model name in logs.
     fn includes_model_name_in_logs(&self) -> bool {
         matches!(self, Self::Show | Self::Delete | Self::Pull | Self::Push)
     }
 }
 
-/// Forwards a request to the Ollama service.
+// Forwards a request to the Ollama service.
 async fn forward_to_ollama<T: Serialize>(
     state: &AppState,
     endpoint: OllamaEndpoint,
@@ -108,12 +108,12 @@ async fn forward_to_ollama<T: Serialize>(
 
     Ok(build_json_response(body_bytes)?)
 }
-/// Handler for listing models (GET /api/tags)
+// Handler for listing models (GET /api/tags)
 pub async fn handle_list_models(State(state): State<AppState>) -> Result<Response, ApiError> {
     forward_to_ollama::<()>(&state, OllamaEndpoint::Tags, None, None).await
 }
 
-/// Handler for showing model details (POST /api/show)
+// Handler for showing model details (POST /api/show)
 pub async fn handle_show_model(
     State(state): State<AppState>,
     Json(request): Json<ModelRequest>,
@@ -127,7 +127,7 @@ pub async fn handle_show_model(
     .await
 }
 
-/// Handler for creating a model (POST /api/create)
+// Handler for creating a model (POST /api/create)
 pub async fn handle_create_model(
     State(state): State<AppState>,
     Json(request): Json<Value>,
@@ -135,7 +135,7 @@ pub async fn handle_create_model(
     forward_to_ollama(&state, OllamaEndpoint::Create, Some(&request), None).await
 }
 
-/// Handler for copying a model (POST /api/copy)
+// Handler for copying a model (POST /api/copy)
 pub async fn handle_copy_model(
     State(state): State<AppState>,
     Json(request): Json<Value>,
@@ -143,7 +143,7 @@ pub async fn handle_copy_model(
     forward_to_ollama(&state, OllamaEndpoint::Copy, Some(&request), None).await
 }
 
-/// Handler for deleting a model (POST /api/delete)
+// Handler for deleting a model (POST /api/delete)
 pub async fn handle_delete_model(
     State(state): State<AppState>,
     Json(request): Json<ModelRequest>,
@@ -157,7 +157,7 @@ pub async fn handle_delete_model(
     .await
 }
 
-/// Handler for pulling a model (POST /api/pull)
+// Handler for pulling a model (POST /api/pull)
 pub async fn handle_pull_model(
     State(state): State<AppState>,
     Json(request): Json<ModelRequest>,
@@ -171,7 +171,7 @@ pub async fn handle_pull_model(
     .await
 }
 
-/// Handler for pushing a model (POST /api/push)
+// Handler for pushing a model (POST /api/push)
 pub async fn handle_push_model(
     State(state): State<AppState>,
     Json(request): Json<ModelRequest>,

--- a/src/handlers/utils.rs
+++ b/src/handlers/utils.rs
@@ -1,18 +1,17 @@
+// In utils.rs
+use crate::{
+    handlers::ApiError,
+    stream::{SecurityAssessable, SecurityAssessedStream, StreamError},
+    AppState,
+};
 use axum::{body::Body, response::Response};
 use bytes::Bytes;
 use futures_util::stream::StreamExt;
 use http_body_util::StreamBody;
 use serde::{de::DeserializeOwned, Serialize};
-use serde_json::json;
 use tracing::error;
 
-use crate::{
-    handlers::ApiError,
-    stream::{SecurityAssessable, SecurityAssessedStream},
-    AppState,
-};
-
-//Builds an HTTP response with JSON content type from the provided bytes.
+// Builds an HTTP response with JSON content type from the provided bytes.
 pub fn build_json_response(bytes: Bytes) -> Result<Response, ApiError> {
     Response::builder()
         .header("Content-Type", "application/json")
@@ -20,11 +19,12 @@ pub fn build_json_response(bytes: Bytes) -> Result<Response, ApiError> {
         .map_err(|e| ApiError::InternalError(format!("Failed to create response: {}", e)))
 }
 
+// Helper function to convert reqwest Error to StreamError
+fn convert_stream_error(_err: reqwest::Error) -> StreamError {
+    StreamError::Unknown
+}
+
 // Handles streaming requests to API endpoints, applying security assessment to the streamed responses.
-//
-// This function takes a request payload, sends it to the specified endpoint using the Ollama client,
-// wraps the resulting stream with security assessment functionality, and returns a properly configured
-// HTTP response that streams the assessed results.
 pub async fn handle_streaming_request<T, R>(
     state: &AppState,
     request: T,
@@ -35,28 +35,49 @@ where
     T: Serialize + Send + 'static,
     R: SecurityAssessable + DeserializeOwned + Serialize + Send + Sync + Unpin + 'static,
 {
-    // No need to clone, we already own the data
+    // Get the original stream from ollama client
     let stream = state.ollama_client.stream(endpoint, &request).await?;
 
+    // Convert the stream to the expected type by mapping the error type
+    let converted_stream = stream.map(|result| match result {
+        Ok(bytes) => Ok(bytes),
+        Err(e) => Err(convert_stream_error(e)),
+    });
+
+    // Create the security-assessed stream
     let assessed_stream = SecurityAssessedStream::<_, R>::new(
-        stream,
+        converted_stream,
         state.security_client.clone(),
         model.to_string(),
     );
 
-    let mapped_stream = StreamExt::map(assessed_stream, |result| match result {
+    // Clone the model string for use in the closure
+    let model_string = model.to_string();
+
+    // Map any errors to bytes for the final stream - add 'move' to take ownership
+    let mapped_stream = assessed_stream.map(move |result| match result {
         Ok(bytes) => Ok::<_, std::convert::Infallible>(bytes),
         Err(e) => {
-            error!("Error in stream: {:?}", e);
-            Ok(Bytes::from(
-                json!({
-                    "error": format!("Stream processing error: {}", e)
-                })
-                .to_string(),
-            ))
+            error!("Error in security assessment stream: {:?}", e);
+            // Convert error to a user-friendly message
+            let error_message = match e {
+                _ => "Error processing response",
+            };
+
+            let error_json = serde_json::json!({
+                "model": model_string, // Use the cloned string here
+                "error": error_message,
+                "done": true
+            });
+
+            let error_bytes = serde_json::to_vec(&error_json)
+                .unwrap_or_else(|_| error_message.as_bytes().to_vec());
+
+            Ok(Bytes::from(error_bytes))
         }
     });
 
+    // Create and return the streaming response
     let stream_body = StreamBody::new(mapped_stream);
     let body = Body::from_stream(stream_body);
 

--- a/src/security.rs
+++ b/src/security.rs
@@ -194,7 +194,6 @@ impl SecurityClient {
                 "PANW Security threat detected! Category: {}, Findings: {:#?}",
                 assessment.category, assessment.details.prompt_detected
             );
-            return Err(SecurityError::BlockedContent);
         }
 
         Ok(assessment)

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,193 +1,172 @@
-use crate::security::{Assessment, SecurityClient};
-use crate::types::{PromptDetected, ResponseDetected, ScanResponse};
+use crate::security::SecurityClient;
 use bytes::Bytes;
 use futures_util::Stream;
 use serde::{de::DeserializeOwned, Serialize};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use thiserror::Error;
-use tracing::{debug, error};
+use tracing::error;
 
+// Errors that can occur during stream processing
 #[derive(Debug, Error)]
 pub enum StreamError {
     #[error("Failed to parse JSON: {0}")]
     JsonError(#[from] serde_json::Error),
-
+    
     #[error("Security assessment failed: {0}")]
     SecurityError(#[from] crate::security::SecurityError),
-
-    #[error("Security issue detected")]
-    SecurityIssue,
-
+    
     #[error("Unknown error")]
     Unknown,
 }
 
-pub struct SecurityAssessedStream<S, T>
-where
-    S: Stream<Item = Result<Bytes, reqwest::Error>>,
-    T: DeserializeOwned + SecurityAssessable + Serialize + Send + Sync + 'static,
-{
-    inner: Pin<Box<S>>,
-    security_client: SecurityClient,
-    model_name: String,
-    buffer: Option<T>,
-    error: Option<StreamError>,
-    finished: bool,
+// Trait for types that can have their content assessed for security issues
+pub trait SecurityAssessable {
+    // Returns content to be assessed and its type
+    fn get_content_for_assessment(&self) -> Option<(&str, &str)>;
 }
 
-pub trait SecurityAssessable {
-    fn get_content_for_assessment(&self) -> Option<(&str, &str)>;
+// A stream wrapper that performs security assessments on each item
+pub struct SecurityAssessedStream<S, T>
+where
+    S: Stream<Item = Result<Bytes, StreamError>> + Unpin,
+    T: DeserializeOwned + SecurityAssessable + Serialize + Send + Sync + 'static,
+{
+    // The underlying stream
+    inner: Pin<Box<S>>,
+    
+    // Client for security assessments
+    security_client: SecurityClient,
+    
+    // Model name for security assessments
+    model_name: String,
+    
+    // Buffer for items being processed
+    buffer: Option<T>,
+    
+    // Whether the stream has finished
+    finished: bool,
 }
 
 impl<S, T> SecurityAssessedStream<S, T>
 where
-    S: Stream<Item = Result<Bytes, reqwest::Error>>,
+    S: Stream<Item = Result<Bytes, StreamError>> + Unpin,
     T: DeserializeOwned + SecurityAssessable + Serialize + Send + Sync + 'static,
 {
+    // Create a new security-assessed stream
     pub fn new(stream: S, security_client: SecurityClient, model_name: String) -> Self {
         Self {
             inner: Box::pin(stream),
             security_client,
             model_name,
             buffer: None,
-            error: None,
             finished: false,
         }
     }
-
-    // Static method to assess content
-    async fn assess_content(
-        security_client: &SecurityClient,
-        model_name: &str,
-        chunk: T,
-    ) -> Result<Assessment, StreamError> {
-        if let Some((content, content_type)) = chunk.get_content_for_assessment() {
-            if !content.is_empty() {
-                debug!("Assessing streaming content of type: {}", content_type);
-                // Determine if this is a prompt or response based on content_type
-                let is_prompt = content_type.contains("prompt");
-                let assessment = security_client
-                    .assess_content(content, model_name, is_prompt)
-                    .await?;
-                if !assessment.is_safe {
-                    error!(
-                        "Security issue detected in streaming content: category={}, action={}",
-                        assessment.category, assessment.action
-                    );
-                    return Err(StreamError::SecurityIssue);
-                }
-                return Ok(assessment);
+    
+    // Create a formatted message for blocked content
+    fn create_blocked_response(&self, category: &str, action: &str) -> Bytes {
+        // Format the blocking message
+        let blocked_message = format!(
+            "⚠️ This response was blocked due to security policy violations:\n\n\
+             • Category: {}\n\
+             • Action: {}\n\n\
+             Please reformulate your request to comply with security policies.",
+            category, action
+        );
+        
+        // Create a standard response structure
+        let response = serde_json::json!({
+            "model": self.model_name,
+            "created_at": chrono::Utc::now().to_rfc3339(),
+            "message": {
+                "role": "assistant",
+                "content": blocked_message
+            },
+            "done": true
+        });
+        
+        // Convert to bytes
+        let json_bytes = serde_json::to_vec(&response)
+            .unwrap_or_else(|_| blocked_message.as_bytes().to_vec());
+            
+        Bytes::from(json_bytes)
+    }
+    
+    // Assess content for security issues
+    fn assess_content(&self, content: &str, content_type: &str) -> Option<Bytes> {
+        // Determine if this is a prompt
+        let is_prompt = content_type.contains("prompt");
+        
+        // Perform the assessment synchronously to avoid threading issues
+        match futures::executor::block_on(async {
+            self.security_client.assess_content(content, &self.model_name, is_prompt).await
+        }) {
+            Ok(assessment) if !assessment.is_safe => {
+                // Content is blocked, return a formatted message
+                Some(self.create_blocked_response(&assessment.category, &assessment.action))
+            },
+            Ok(_) => {
+                // Content is safe
+                None
+            },
+            Err(_) => {
+                // Error during assessment, continue with original content
+                None
             }
         }
-
-        // If there's no content to assess or it's empty, consider it safe
-        Ok(Assessment {
-            is_safe: true,
-            category: "benign".to_string(),
-            action: "allow".to_string(),
-            details: ScanResponse {
-                report_id: "".to_string(),
-                scan_id: uuid::Uuid::default(),
-                tr_id: None,
-                profile_id: None,
-                profile_name: None,
-                category: "benign".to_string(),
-                action: "allow".to_string(),
-                prompt_detected: PromptDetected {
-                    url_cats: false,
-                    dlp: false,
-                    injection: false,
-                    toxic_content: false,
-                    malicious_code: false,
-                },
-                response_detected: ResponseDetected {
-                    url_cats: false,
-                    dlp: false,
-                    db_security: false,
-                    toxic_content: false,
-                    malicious_code: false,
-                },
-                created_at: None,
-                completed_at: None,
-            },
-        })
     }
 }
 
 impl<S, T> Stream for SecurityAssessedStream<S, T>
 where
-    S: Stream<Item = Result<Bytes, reqwest::Error>> + Unpin,
+    S: Stream<Item = Result<Bytes, StreamError>> + Unpin,
     T: DeserializeOwned + SecurityAssessable + Serialize + Unpin + Send + Sync + 'static,
 {
     type Item = Result<Bytes, StreamError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        // Early return for finished state
+        // Handle finished state
         if self.finished {
             return Poll::Ready(None);
         }
-
-        // Handle pending errors first
-        if let Some(err) = self.error.take() {
-            self.finished = true;
-            return Poll::Ready(Some(Err(err)));
-        }
-
-        // Process buffered items before polling the inner stream
+        
+        // Process any buffered items first
         if let Some(item) = self.buffer.take() {
-            let json = match serde_json::to_vec(&item) {
-                Ok(json) => json,
+            match serde_json::to_vec(&item) {
+                Ok(json) => return Poll::Ready(Some(Ok(Bytes::from(json)))),
                 Err(e) => return Poll::Ready(Some(Err(StreamError::JsonError(e)))),
-            };
-            return Poll::Ready(Some(Ok(Bytes::from(json))));
+            }
         }
-
+        
+        // Poll the inner stream
         match self.inner.as_mut().poll_next(cx) {
             Poll::Ready(Some(Ok(bytes))) => {
+                // Try to parse the bytes
                 match serde_json::from_slice::<T>(&bytes) {
                     Ok(chunk) => {
-                        // Clone bytes before moving to async task
-                        let bytes_clone = bytes.clone();
-
-                        // We need to return to the executor to do the async assessment
-                        let this = self.get_mut();
-                        let security_client = this.security_client.clone();
-                        let model_name = this.model_name.clone();
-
-                        tokio::spawn(async move {
-                            // Use the static method to avoid type mismatch issues
-                            // Pass chunk by value instead of reference
-                            let result = match SecurityAssessedStream::<S, T>::assess_content(
-                                &security_client,
-                                &model_name,
-                                chunk,
-                            )
-                            .await
-                            {
-                                Ok(_) => Ok(bytes_clone),
-                                Err(e) => Err(e),
-                            };
-                            result
-                        });
-
-                        // Return the original bytes without waiting for assessment
+                        // Check if there's content to assess
+                        if let Some((content, content_type)) = chunk.get_content_for_assessment() {
+                            if !content.is_empty() {
+                                // Assess content for security issues
+                                if let Some(blocked_response) = self.assess_content(content, content_type) {
+                                    // Return blocked response
+                                    return Poll::Ready(Some(Ok(blocked_response)));
+                                }
+                            }
+                        }
+                        
+                        // If we reach here, content is safe or couldn't be assessed
                         Poll::Ready(Some(Ok(bytes)))
-                    }
+                    },
                     Err(e) => {
                         error!("Failed to parse JSON in stream: {}", e);
                         Poll::Ready(Some(Err(StreamError::JsonError(e))))
                     }
                 }
-            }
-            Poll::Ready(Some(Err(e))) => {
-                error!("Error in stream: {}", e);
-                Poll::Ready(Some(Err(StreamError::Unknown)))
-            }
-            Poll::Ready(None) => {
-                debug!("Stream ended");
-                Poll::Ready(None)
-            }
+            },
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
+            Poll::Ready(None) => Poll::Ready(None),
             Poll::Pending => Poll::Pending,
         }
     }


### PR DESCRIPTION
## Description

This PR modifies how security violations are handled in the application. Instead of returning generic 500 Internal Server Error responses when content violates security policies, we now format and return proper responses with clear explanations of why the content was blocked.

## Changes

- Modified security assessment processing to return assessments with `is_safe: false` instead of throwing errors
- Implemented formatted blocking messages that explain the security violation category and action
- Updated stream handling to properly format and return these messages
- Maintained compatibility with OpenWebUI by preserving the expected response structure

## Benefits

- Users receive clear explanations about why their content was blocked
- Improved user experience by eliminating generic 500 errors
- Better security transparency without exposing sensitive details
- Consistent response structure preserves client compatibility

## Testing

Tested with various security violation scenarios to ensure proper formatting and response status codes.
