### PR TITLE
Pin specific commit SHAs for GitHub Actions in CI Workflow

### DIFF
--- a/.github/workflows/docker-publish-multi-platform.yml
+++ b/.github/workflows/docker-publish-multi-platform.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -32,7 +32,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -43,7 +43,7 @@ jobs:
             type=sha
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Description

GitHub recommends pinning actions to a full length commit SHA, as this is currently the only method of using an action as an immutable release.

For more information refer to: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

## What is done ?
This pull request updates the .github/workflows/docker-publish-multi-platform.yml file to reference specific commit SHAs for GitHub Actions instead of version tags. This ensures stability and security by locking the workflow to immutable versions of the actions. The changes affect the following actions:

actions/checkout pinned to 11bd71901bbe5b1630ceea73d27597364c9af683 (#v4)
docker/setup-buildx-action pinned to b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 (#v3)
docker/login-action pinned to 74a5d142397b4f367a81961eba4e8cd7edddf772 (#v3)
docker/metadata-action pinned to 902fa8ec7d6ecbf8d84d538b9b233a880e428804 (#v5)
docker/build-push-action pinned to ca052bb54ab0790a636c9b5f226502c73d547a25 (#v5)

These updates align with best practices for CI/CD workflows, enhancing reproducibility and mitigating the risks of unexpected changes or vulnerabilities from updated tags.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
