### PR TITLE
chore(security): wrap api_key in SecretString

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ flake.lock
 # that should not be shared.
 config.yaml
 .env
+.claude-octopus/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,7 @@ dependencies = [
  "http-body-util",
  "pin-project",
  "reqwest",
+ "secrecy",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -1091,6 +1092,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "serde",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ async-stream = "0.3.6"
 http-body-util = "0.1.3"
 chrono = { version = "0.4.44", features = ["serde", "clock"], default-features = false }
 pin-project = "1.1.13"
+secrecy = { version = "0.10.3", features = ["serde"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@
 /// 2. Parse into structured types
 /// 3. Validate all required settings
 /// 4. Make configuration available to application components
+use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use std::env;
 use std::fs;
@@ -88,8 +89,10 @@ pub struct SecurityConfig {
     /// Base URL of the PANW AI Runtime security API
     pub base_url: String,
 
-    /// API key for authenticating with the security service
-    pub api_key: String,
+    /// API key for authenticating with the security service.
+    /// Wrapped in `SecretString` to prevent accidental disclosure via
+    /// `Debug`, `Display`, default `serde::Serialize`, or `format!`.
+    pub api_key: SecretString,
 
     /// Security profile name to use for assessments
     pub profile_name: String,
@@ -133,7 +136,7 @@ fn load_from_env() -> Config {
     let security = SecurityConfig {
         base_url: env::var("SECURITY_BASE_URL")
             .unwrap_or_else(|_| "https://service.api.aisecurity.paloaltonetworks.com".to_string()),
-        api_key: env::var("SECURITY_API_KEY").unwrap_or_default(),
+        api_key: SecretString::from(env::var("SECURITY_API_KEY").unwrap_or_default()),
         profile_name: env::var("SECURITY_PROFILE_NAME").unwrap_or_default(),
         app_name: env::var("SECURITY_APP_NAME").unwrap_or_else(|_| "panw-api-ollama".to_string()),
         app_user: env::var("SECURITY_APP_USER").unwrap_or_else(|_| "default".to_string()),
@@ -226,7 +229,7 @@ fn override_with_env(config: &mut Config) {
     }
 
     if let Ok(api_key) = env::var("SECURITY_API_KEY") {
-        config.security.api_key = api_key;
+        config.security.api_key = SecretString::from(api_key);
     }
 
     if let Ok(profile_name) = env::var("SECURITY_PROFILE_NAME") {
@@ -280,7 +283,7 @@ impl Config {
         }
 
         // Validate security config - API credentials
-        if self.security.base_url.is_empty() || self.security.api_key.is_empty() {
+        if self.security.base_url.is_empty() || self.security.api_key.expose_secret().is_empty() {
             return Err(ConfigError::ValidationError(
                 "Security credentials missing (base_url or api_key)".into(),
             ));
@@ -313,5 +316,54 @@ impl Config {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(api_key: &str) -> Config {
+        Config {
+            server: ServerConfig {
+                host: "127.0.0.1".into(),
+                port: 11435,
+                debug_level: "INFO".into(),
+            },
+            ollama: OllamaConfig {
+                base_url: "http://localhost:11434".into(),
+            },
+            security: SecurityConfig {
+                base_url: "https://example.invalid".into(),
+                api_key: SecretString::from(api_key),
+                profile_name: "p".into(),
+                app_name: "a".into(),
+                app_user: "u".into(),
+                contextual_grounding: String::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn debug_format_redacts_api_key() {
+        let c = cfg("super-secret-token-do-not-leak");
+        let dbg = format!("{:?}", c);
+        assert!(
+            !dbg.contains("super-secret-token-do-not-leak"),
+            "api_key leaked through Debug: {dbg}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_empty_api_key() {
+        let c = cfg("");
+        let err = c.validate().unwrap_err();
+        assert!(matches!(err, ConfigError::ValidationError(_)));
+    }
+
+    #[test]
+    fn validate_accepts_non_empty_api_key() {
+        let c = cfg("present");
+        c.validate().unwrap();
     }
 }

--- a/src/security.rs
+++ b/src/security.rs
@@ -37,6 +37,7 @@ use crate::{
     types::{AiProfile, Content, Metadata, ScanRequest, ScanResponse},
 };
 use reqwest::Client;
+use secrecy::{ExposeSecret, SecretString};
 use std::time::Instant;
 use thiserror::Error;
 use tracing::{debug, error, info, warn};
@@ -134,8 +135,9 @@ pub struct SecurityClient {
     // Base URL for the PANW API service
     base_url: String,
 
-    // API key for authenticating with PANW services
-    api_key: String,
+    // API key for authenticating with PANW services. Exposed only at the HTTP
+    // send site via `expose_secret()`; never logged, formatted, or serialized.
+    api_key: SecretString,
 
     // Security profile name to use for assessments
     profile_name: String,
@@ -741,7 +743,7 @@ impl SecurityClient {
             .client
             .post(&endpoint)
             .header("Content-Type", "application/json")
-            .header("x-pan-token", &self.api_key)
+            .header("x-pan-token", self.api_key.expose_secret())
             .json(payload)
             .send()
             .await
@@ -849,7 +851,7 @@ mod tests {
     fn client() -> SecurityClient {
         SecurityClient::new(SecurityConfig {
             base_url: "https://example.invalid".into(),
-            api_key: "test".into(),
+            api_key: SecretString::from("test"),
             profile_name: "p".into(),
             app_name: "test".into(),
             app_user: "u".into(),


### PR DESCRIPTION
## Summary
- Wraps `SecurityConfig::api_key` in `secrecy::SecretString` so it cannot leak via `Debug`, `Display`, default `serde::Serialize`, or `format!`.
- Exposes the secret only at the HTTP send site via `expose_secret()` when setting the `x-pan-token` header.
- Adds 3 tests: Debug redaction, empty-key validation rejection, non-empty validation acceptance.

## Why
A custom `Debug` impl alone protects only `{:?}` formatting; `SecretString` blocks every common exposure vector at compile time, surfacing intentional disclosures via `.expose_secret()`.

## Test plan
- [x] `cargo build` clean
- [x] `cargo test` — 27 passed (24 prior + 3 new)
- [x] `format!("{:?}", config)` does not contain raw key