### PR TITLE
refactor: propagate reqwest errors from client builders

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -207,14 +207,14 @@ fn build_app_state(
     info!("Building application state with configured clients");
 
     // Create Ollama client
-    let ollama_client = OllamaClient::new(ollama_base_url.clone());
+    let ollama_client = OllamaClient::new(ollama_base_url.clone())?;
     info!(
         "Created Ollama client with base URL: {}",
         ollama_base_url
     );
 
     // Create security client
-    let security_client = SecurityClient::new(security_config);
+    let security_client = SecurityClient::new(security_config)?;
 
     info!(
         "Created security client with base URL: {}",

--- a/src/ollama.rs
+++ b/src/ollama.rs
@@ -71,7 +71,7 @@ impl OllamaClient {
     // ```
     // let client = OllamaClient::new("http://localhost:11434");
     // ```
-    pub fn new(base_url: String) -> Self {
+    pub fn new(base_url: String) -> Result<Self, reqwest::Error> {
         // Ollama generations can legitimately take many minutes; do NOT set an
         // overall request timeout. Cap connect time and per-chunk read instead.
         let client = Client::builder()
@@ -81,9 +81,8 @@ impl OllamaClient {
             .pool_idle_timeout(std::time::Duration::from_secs(90))
             .tcp_keepalive(std::time::Duration::from_secs(30))
             .user_agent(concat!("panw-api-ollama/", env!("CARGO_PKG_VERSION")))
-            .build()
-            .expect("ollama reqwest client build");
-        Self { client, base_url }
+            .build()?;
+        Ok(Self { client, base_url })
     }
 
     //--------------------------------------------------------------------------

--- a/src/security.rs
+++ b/src/security.rs
@@ -268,7 +268,7 @@ impl SecurityClient {
     // * `profile_name` - Name of the AI security profile to use for assessments
     // * `app_name` - Name of the application using this security client
     // * `app_user` - Identifier for the user or context within the application
-    pub fn new(config: SecurityConfig) -> Self {
+    pub fn new(config: SecurityConfig) -> Result<Self, reqwest::Error> {
         // PANW scan calls must be bounded; runaway requests cannot block the proxy
         // tokio runtime indefinitely.
         let client = Client::builder()
@@ -280,9 +280,8 @@ impl SecurityClient {
             .https_only(true)
             .min_tls_version(reqwest::tls::Version::TLS_1_2)
             .user_agent(concat!("panw-api-ollama/", env!("CARGO_PKG_VERSION")))
-            .build()
-            .expect("PANW reqwest client build");
-        Self {
+            .build()?;
+        Ok(Self {
             client,
             base_url: config.base_url,
             api_key: config.api_key,
@@ -291,7 +290,7 @@ impl SecurityClient {
             app_user: config.app_user,
             contextual_grounding_context: config.contextual_grounding,
             user_ip: None,
-        }
+        })
     }
 
     //--------------------------------------------------------------------------
@@ -855,6 +854,7 @@ mod tests {
             app_user: "u".into(),
             contextual_grounding: String::new(),
         })
+        .expect("test SecurityClient build")
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `OllamaClient::new` returns `Result<Self, reqwest::Error>` instead of `Self` with `.expect("ollama reqwest client build")`.
- `SecurityClient::new` returns `Result<Self, reqwest::Error>` instead of `Self` with `.expect("PANW reqwest client build")`.
- `main::build_app_state` propagates the error via `?`; existing tests use `.expect("test SecurityClient build")` to keep panics scoped to test setup.

## Why
HTTP client construction can fail in real environments (e.g., hardened TLS configuration, missing CA bundle). Panicking from `expect` produces a process abort with no clean shutdown path; returning `Result` lets `main()` surface the error and exit non-zero with a tracing log.

## Test plan
- [x] `cargo build` clean
- [x] `cargo test` - 24 passed (no regression)