### PR TITLE
fix(security): redact PANW response body in operational logs

### DIFF
--- a/src/security.rs
+++ b/src/security.rs
@@ -39,8 +39,34 @@ use crate::{
 use reqwest::Client;
 use std::time::Instant;
 use thiserror::Error;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, trace, warn};
 use uuid::Uuid;
+
+// Maximum length of a PANW response body included verbatim in error logs.
+// The full body can echo user prompts and model responses. Truncating to a
+// short prefix lets operators correlate failures without persisting sensitive
+// content in INFO/ERROR-level logs.
+const PANW_BODY_LOG_PREFIX_LEN: usize = 256;
+
+// Returns a body excerpt suitable for ERROR-level logging: a short prefix
+// followed by an explicit truncation marker. Full body remains available at
+// `trace!` level for ad-hoc debugging.
+fn body_excerpt(body: &str) -> String {
+    if body.len() <= PANW_BODY_LOG_PREFIX_LEN {
+        body.to_string()
+    } else {
+        let mut end = PANW_BODY_LOG_PREFIX_LEN;
+        // Avoid splitting a UTF-8 multibyte character.
+        while end > 0 && !body.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!(
+            "{}... [truncated, {} bytes total]",
+            &body[..end],
+            body.len()
+        )
+    }
+}
 
 // Represents errors that can occur during security assessments with the PANW AI Runtime API.
 //
@@ -774,13 +800,20 @@ impl SecurityClient {
         status: reqwest::StatusCode,
         body_text: String,
     ) -> Result<ScanResponse, SecurityError> {
-        // Log the raw response in debug mode
+        // PANW response bodies can echo user prompts, model responses, and
+        // masked-DLP findings. Log the status at debug level; restrict the
+        // raw body to trace level so it never appears in standard logs.
         debug!("PANW API response status: {}", status);
-        debug!("Raw PANW response body:\n{}", body_text);
+        trace!(target: "panw::raw_body", "Raw PANW response body:\n{}", body_text);
 
         // Handle error status codes based on OpenAPI specification
         if !status.is_success() {
-            error!("PANW security assessment error: {} - {}", status, body_text);
+            // Log a bounded excerpt; never the full body at error level.
+            error!(
+                "PANW security assessment error: status={} body_excerpt={}",
+                status,
+                body_excerpt(&body_text)
+            );
 
             // Parse error response if possible
             let error_details = match serde_json::from_str::<serde_json::Value>(&body_text) {
@@ -845,6 +878,31 @@ impl SecurityClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn body_excerpt_passes_through_short_bodies() {
+        let s = "short body";
+        assert_eq!(body_excerpt(s), s);
+    }
+
+    #[test]
+    fn body_excerpt_truncates_long_bodies() {
+        let body = "x".repeat(PANW_BODY_LOG_PREFIX_LEN + 100);
+        let out = body_excerpt(&body);
+        assert!(out.len() < body.len());
+        assert!(out.contains("truncated"));
+        assert!(out.contains(&format!("{} bytes", body.len())));
+    }
+
+    #[test]
+    fn body_excerpt_handles_utf8_boundary() {
+        // Build a body whose byte at the cut-off is mid-multibyte.
+        let mut body = "a".repeat(PANW_BODY_LOG_PREFIX_LEN - 1);
+        body.push_str("é"); // 2 bytes; cut would split it.
+        body.push_str("more text");
+        // Should not panic and should produce valid UTF-8.
+        let _ = body_excerpt(&body);
+    }
 
     fn client() -> SecurityClient {
         SecurityClient::new(SecurityConfig {


### PR DESCRIPTION
## Summary
- Replace `debug!("Raw PANW response body:\n{}", body_text)` with `trace!(target: "panw::raw_body", ...)` so the full body never appears in standard log output.
- Replace verbatim error-log of full body with a bounded `body_excerpt` (256-byte prefix + truncation marker, UTF-8 boundary aware).
- Adds 3 unit tests for `body_excerpt`.

## Why
PANW scan response bodies echo user prompts, model output, and masked-DLP findings. Logging them verbatim at debug/error level persists sensitive content in every downstream log sink. The trace target lets operators opt-in for ad-hoc debugging without making it the default.

## Test plan
- [x] `cargo test` - 27 passed (24 prior + 3 new)
- [x] Truncation produces valid UTF-8 even mid-multibyte