### PR TITLE
perf(stream): skip empty code-buffer clone in assessment future

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -588,28 +588,29 @@ fn create_security_assessment_future(
     model_name: &str,
     is_prompt: bool,
 ) -> AssessmentFuture {
-    // Get the separate content buffers
-    let text_content = buffer.text_buffer.clone();
-    let code_content = buffer.code_buffer.clone();
-
-    // Clone what we need for the async block
     let client = security_client.clone();
     let model = model_name.to_string();
+    // Decide which path to take BEFORE allocating the second buffer copy:
+    // when there is no code content the future does not need the empty
+    // `code_buffer` and the heap copy is pointless.
+    let has_code = !buffer.code_buffer.is_empty();
+    let text_content = buffer.text_buffer.clone();
+    let code_content = if has_code {
+        Some(buffer.code_buffer.clone())
+    } else {
+        None
+    };
 
-    // Create assessment future with appropriate content based on what we have
     Box::pin(async move {
-        // If we have code content, include it in the assessment
-        if !code_content.is_empty() {
-            client
-                .assess_content_with_code(&text_content, &code_content, &model, is_prompt)
+        match code_content {
+            Some(code) => client
+                .assess_content_with_code(&text_content, &code, &model, is_prompt)
                 .await
-                .map_err(|e| StreamError::SecurityError(e.to_string()))
-        } else {
-            // Otherwise just assess the text
-            client
+                .map_err(|e| StreamError::SecurityError(e.to_string())),
+            None => client
                 .assess_content(&text_content, &model, is_prompt)
                 .await
-                .map_err(|e| StreamError::SecurityError(e.to_string()))
+                .map_err(|e| StreamError::SecurityError(e.to_string())),
         }
     })
 }


### PR DESCRIPTION
## Summary
- `create_security_assessment_future` previously cloned both `text_buffer` and `code_buffer` unconditionally, then branched on `!code_content.is_empty()` inside the async block.
- New code branches on `!buffer.code_buffer.is_empty()` BEFORE allocating; the code-buffer clone is wrapped in `Option<String>` and only allocated when the code-aware path is taken.

## Why
Benign chat traffic without fenced code blocks - the dominant case for many proxies - was paying for a zero-byte `String::clone` on every assessment kickoff. The behavior is unchanged; we just stop allocating an empty buffer for nothing.

## Test plan
- [x] `cargo test` - 24 passed (no regression)
- [ ] Future work: micro-benchmark to quantify savings (the underlying clones of non-empty buffers and the model `String` are still cheap relative to the network RTT).