### PR TITLE
perf(security): preallocate buffers in extract_code_blocks

### DIFF
--- a/src/security.rs
+++ b/src/security.rs
@@ -507,9 +507,12 @@ impl SecurityClient {
     //
     // A string containing all extracted code blocks concatenated together
     fn extract_code_blocks(&self, content: &str) -> String {
-        let mut code_content = String::new();
+        // Worst case the entire input is code; preallocating to `content.len()`
+        // bounds the result and avoids repeated `String::push_str` realloc
+        // chains for large code-heavy responses.
+        let mut code_content = String::with_capacity(content.len());
         let mut in_code_block = false;
-        let mut buffer = String::new();
+        let mut buffer = String::with_capacity(content.len());
 
         for line in content.lines() {
             let trimmed = line.trim();


### PR DESCRIPTION
## Summary
- `String::with_capacity(content.len())` for both `code_content` and the per-block `buffer`.

## Why
Avoids the geometric reallocation chain on `push_str` for code-heavy responses. \`content.len()\` is a tight upper bound on either accumulator's final size.

## Test plan
- [x] \`cargo test\` - 24 passed, no behavior change