### PR TITLE
fix(security): bump body_excerpt cap from 256 to 1024 bytes

### DIFF
--- a/src/security.rs
+++ b/src/security.rs
@@ -45,9 +45,13 @@ use uuid::Uuid;
 
 // Maximum length of a PANW response body included verbatim in error logs.
 // The full body can echo user prompts and model responses. Truncating to a
-// short prefix lets operators correlate failures without persisting sensitive
-// content in INFO/ERROR-level logs.
-const PANW_BODY_LOG_PREFIX_LEN: usize = 256;
+// bounded prefix lets operators correlate failures without persisting
+// sensitive content in INFO/ERROR-level logs.
+//
+// 1024 bytes accommodates a typical PANW JSON error envelope
+// (`{"error":{"message":"...","request_id":"...","retry_after":{...}}}`)
+// without truncation while still bounding the worst case.
+const PANW_BODY_LOG_PREFIX_LEN: usize = 1024;
 
 // Returns a body excerpt suitable for ERROR-level logging: a short prefix
 // followed by an explicit truncation marker. Full body remains available at


### PR DESCRIPTION
## Summary
One-constant change in src/security.rs: PANW_BODY_LOG_PREFIX_LEN 256 -> 1024.

## Why
Per debate-gate-2 follow-up: 256 bytes was too tight for a typical PANW JSON error envelope. 1024 fits a full envelope (error.message + request_id + retry_after) without truncation while still bounding worst case.

## Test plan
- [x] cargo test - 47 passed (existing body_excerpt tests size-relative)