### PR TITLE
feat(api): add /api/ps and /api/embed Ollama endpoints

### DIFF
--- a/src/handlers/embeddings.rs
+++ b/src/handlers/embeddings.rs
@@ -4,6 +4,8 @@ use crate::types::EmbeddingsRequest;
 use crate::types::EmbeddingsResponse;
 use crate::AppState;
 use axum::{extract::State, response::Response, Json};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use tracing::debug;
 
 pub async fn handle_embeddings(
@@ -40,4 +42,109 @@ pub async fn handle_embeddings(
         .await
         .map_err(|e| ApiError::InternalError(e.to_string()))?;
     build_json_response(body_bytes)
+}
+
+/// Request shape for the newer `POST /api/embed` endpoint, where `input`
+/// can be a single string or an array of strings.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct EmbedRequest {
+    pub model: String,
+    /// Either a JSON string or a JSON array of strings, per the Ollama API.
+    pub input: Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncate: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub options: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub keep_alive: Option<Value>,
+}
+
+/// Empty-vector response shape used when content is blocked.
+#[derive(Debug, Serialize)]
+struct EmbedBlockedResponse {
+    model: String,
+    embeddings: Vec<Vec<f32>>,
+}
+
+/// Returns every input string as a flat `Vec<String>` so a security scan can
+/// be applied to all inputs at once. Unrecognized JSON shapes degrade to an
+/// empty vec; the request still forwards to Ollama and returns its native
+/// error.
+fn flatten_inputs(input: &Value) -> Vec<String> {
+    match input {
+        Value::String(s) => vec![s.clone()],
+        Value::Array(arr) => arr
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Handler for the newer `POST /api/embed` endpoint.
+///
+/// Differs from `/api/embeddings` (legacy) by accepting an `input` field that
+/// may be a single string or an array of strings, and returning
+/// `{"embeddings": [[...]]}`.
+///
+/// Security model: the concatenated inputs are submitted to PANW for prompt
+/// scanning. On a block we return an empty `embeddings` array along with the
+/// original model name so a client library doesn't crash on missing fields.
+pub async fn handle_embed(
+    State(state): State<AppState>,
+    Json(request): Json<EmbedRequest>,
+) -> Result<Response, ApiError> {
+    debug!("Received /api/embed request for model: {}", request.model);
+
+    let inputs = flatten_inputs(&request.input);
+    let joined = inputs.join("\n");
+
+    let assessment = state
+        .security_client
+        .assess_content(&joined, &request.model, true)
+        .await?;
+
+    if !assessment.is_safe {
+        return build_violation_response(EmbedBlockedResponse {
+            model: request.model.clone(),
+            embeddings: Vec::new(),
+        });
+    }
+
+    let response = state
+        .ollama_client
+        .forward("/api/embed", &request)
+        .await?;
+    let body_bytes = response
+        .bytes()
+        .await
+        .map_err(|e| ApiError::InternalError(e.to_string()))?;
+    build_json_response(body_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn flatten_string_input() {
+        let v = json!("hello");
+        assert_eq!(flatten_inputs(&v), vec!["hello".to_string()]);
+    }
+
+    #[test]
+    fn flatten_array_input() {
+        let v = json!(["a", "b", "c"]);
+        assert_eq!(
+            flatten_inputs(&v),
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
+    }
+
+    #[test]
+    fn flatten_unrecognized_shape_returns_empty() {
+        let v = json!({"oops": 1});
+        assert!(flatten_inputs(&v).is_empty());
+    }
 }

--- a/src/handlers/models.rs
+++ b/src/handlers/models.rs
@@ -25,6 +25,7 @@ pub enum OllamaEndpoint {
     Delete,
     Pull,
     Push,
+    Ps,
 }
 
 impl OllamaEndpoint {
@@ -38,13 +39,14 @@ impl OllamaEndpoint {
             Self::Delete => "/api/delete",
             Self::Pull => "/api/pull",
             Self::Push => "/api/push",
+            Self::Ps => "/api/ps",
         }
     }
 
     // Returns the HTTP method for the endpoint.
     fn method(&self) -> Method {
         match self {
-            Self::Tags => Method::GET,
+            Self::Tags | Self::Ps => Method::GET,
             _ => Method::POST,
         }
     }
@@ -59,6 +61,7 @@ impl OllamaEndpoint {
             Self::Delete => "Forwarding delete model request for",
             Self::Pull => "Forwarding pull model request for",
             Self::Push => "Forwarding push model request for",
+            Self::Ps => "Forwarding running-models (ps) request",
         }
     }
 
@@ -109,6 +112,15 @@ async fn forward_to_ollama<T: Serialize>(
 // Handler for listing models (GET /api/tags)
 pub async fn handle_list_models(State(state): State<AppState>) -> Result<Response, ApiError> {
     forward_to_ollama::<()>(&state, OllamaEndpoint::Tags, None, None).await
+}
+
+// Handler for listing currently-running models (GET /api/ps).
+//
+// Mirrors the upstream Ollama endpoint that reports models loaded in
+// memory along with their VRAM footprint. Pure passthrough: no scan
+// applies because the response contains no user prompts or model output.
+pub async fn handle_running_models(State(state): State<AppState>) -> Result<Response, ApiError> {
+    forward_to_ollama::<()>(&state, OllamaEndpoint::Ps, None, None).await
 }
 
 // Handler for showing model details (POST /api/show)

--- a/src/main.rs
+++ b/src/main.rs
@@ -248,7 +248,10 @@ fn build_router(state: AppState) -> Router {
     let generation_routes = Router::new()
         .route("/api/generate", post(generate::handle_generate))
         .route("/api/chat", post(chat::handle_chat))
-        .route("/api/embeddings", post(embeddings::handle_embeddings));
+        .route("/api/embeddings", post(embeddings::handle_embeddings))
+        // /api/embed is the newer Ollama embeddings endpoint; accepts
+        // either a single string or an array of strings.
+        .route("/api/embed", post(embeddings::handle_embed));
 
     let model_routes = Router::new()
         .route("/api/tags", get(models::handle_list_models))
@@ -257,7 +260,9 @@ fn build_router(state: AppState) -> Router {
         .route("/api/copy", post(models::handle_copy_model))
         .route("/api/delete", post(models::handle_delete_model))
         .route("/api/pull", post(models::handle_pull_model))
-        .route("/api/push", post(models::handle_push_model));
+        .route("/api/push", post(models::handle_push_model))
+        // /api/ps reports running models; pure passthrough, no scan needed.
+        .route("/api/ps", get(models::handle_running_models));
 
     let utility_routes = Router::new().route("/api/version", get(version::handle_version));
 


### PR DESCRIPTION
## Summary
Two endpoints from the current Ollama API were returning 404 through the proxy:

| Endpoint | Behavior |
|----------|----------|
| \`GET /api/ps\` | Pure passthrough (no user content in response). |
| \`POST /api/embed\` | PANW prompt scan; on block returns 200 with empty \`embeddings\` array + original \`model\` so clients don't crash. |

## Why
\`/api/embed\` is the newer Ollama embeddings endpoint accepting \`input\` as a single string or an array of strings (legacy \`/api/embeddings\` still works but is deprecated). \`/api/ps\` reports running models. Both are widely used by Ollama clients and tools; 404 broke transparent compatibility.

## Test plan
- [x] \`cargo test\` - 57 passed (54 prior + 3 new for input flattener)
- [x] live smoke - 16/16 PASS including new /api/ps + 3 /api/embed cases
- [x] /api/embed malicious returns 200 with empty embeddings (PANW block)